### PR TITLE
feat: implement true flexible slot scheduling

### DIFF
--- a/backend/alembic/versions/002_schedule_flexible_mode.py
+++ b/backend/alembic/versions/002_schedule_flexible_mode.py
@@ -1,0 +1,34 @@
+"""add flexible schedule columns
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-02
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("schedules", sa.Column("schedule_mode", sa.String(length=32), nullable=True))
+    op.add_column("schedules", sa.Column("slot_date", sa.Date(), nullable=True))
+
+    op.execute("UPDATE schedules SET schedule_mode = 'weekly' WHERE schedule_mode IS NULL")
+
+    op.alter_column("schedules", "schedule_mode", existing_type=sa.String(length=32), nullable=False)
+    op.alter_column("schedules", "day_of_week", existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("schedules", "day_of_week", existing_type=sa.Integer(), nullable=False)
+    op.drop_column("schedules", "slot_date")
+    op.drop_column("schedules", "schedule_mode")

--- a/backend/app/models/schedule.py
+++ b/backend/app/models/schedule.py
@@ -1,6 +1,6 @@
 import datetime
 
-from sqlalchemy import ForeignKey, Integer, Time
+from sqlalchemy import Date, ForeignKey, Integer, String, Time
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -16,7 +16,9 @@ class Schedule(Base):
     resource_id: Mapped[int | None] = mapped_column(
         ForeignKey("resources.id"), nullable=True, index=True
     )
-    day_of_week: Mapped[int] = mapped_column(Integer, nullable=False)  # 0=Monday .. 6=Sunday
+    schedule_mode: Mapped[str] = mapped_column(String(32), nullable=False, default="weekly")  # weekly | flexible
+    day_of_week: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0=Monday .. 6=Sunday
+    slot_date: Mapped[datetime.date | None] = mapped_column(Date, nullable=True)
     start_time: Mapped[datetime.time] = mapped_column(Time, nullable=False)
     end_time: Mapped[datetime.time] = mapped_column(Time, nullable=False)
 

--- a/backend/app/routers/appointments.py
+++ b/backend/app/routers/appointments.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import time
+from datetime import date, time
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -32,8 +32,10 @@ def _serialize_schedule(s: Schedule) -> ScheduleOut:
     return ScheduleOut(
         id=s.id,
         appointment_type_id=s.appointment_type_id,
+        schedule_mode=s.schedule_mode,
         resource_id=s.resource_id,
         day_of_week=s.day_of_week,
+        slot_date=s.slot_date.isoformat() if s.slot_date else None,
         start_time=s.start_time.strftime("%H:%M"),
         end_time=s.end_time.strftime("%H:%M"),
     )
@@ -234,12 +236,23 @@ def add_schedule(
     at = db.get(AppointmentType, appointment_id)
     if not at or at.organiser_id != user.id:
         raise HTTPException(status_code=404, detail="Not found")
-    sh, sm = data.start_time.split(":")
-    eh, em = data.end_time.split(":")
+    try:
+        sh, sm = data.start_time.split(":")
+        eh, em = data.end_time.split(":")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid time format")
+    slot_date = None
+    if data.slot_date:
+        try:
+            slot_date = date.fromisoformat(data.slot_date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid slot_date format")
     s = Schedule(
         appointment_type_id=appointment_id,
+        schedule_mode=data.schedule_mode,
         resource_id=data.resource_id,
         day_of_week=data.day_of_week,
+        slot_date=slot_date,
         start_time=time(int(sh), int(sm)),
         end_time=time(int(eh), int(em)),
     )

--- a/backend/app/schemas/appointment.py
+++ b/backend/app/schemas/appointment.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ResourceCreate(BaseModel):
@@ -16,17 +16,37 @@ class ResourceOut(BaseModel):
 
 
 class ScheduleCreate(BaseModel):
+    schedule_mode: str = "weekly"
     resource_id: int | None = None
-    day_of_week: int = Field(..., ge=0, le=6)
+    day_of_week: int | None = Field(None, ge=0, le=6)
+    slot_date: str | None = None
     start_time: str  # "HH:MM"
     end_time: str
+
+    @model_validator(mode="after")
+    def validate_schedule_mode_fields(self):
+        if self.schedule_mode not in {"weekly", "flexible"}:
+            raise ValueError("schedule_mode must be weekly or flexible")
+        if self.schedule_mode == "weekly":
+            if self.day_of_week is None:
+                raise ValueError("day_of_week is required for weekly schedules")
+            if self.slot_date is not None:
+                raise ValueError("slot_date is not allowed for weekly schedules")
+        else:
+            if self.slot_date is None:
+                raise ValueError("slot_date is required for flexible schedules")
+            if self.day_of_week is not None:
+                raise ValueError("day_of_week is not allowed for flexible schedules")
+        return self
 
 
 class ScheduleOut(BaseModel):
     id: int
     appointment_type_id: int
+    schedule_mode: str
     resource_id: int | None
-    day_of_week: int
+    day_of_week: int | None
+    slot_date: str | None
     start_time: str
     end_time: str
 

--- a/backend/app/services/availability.py
+++ b/backend/app/services/availability.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta, timezone
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -26,7 +26,10 @@ def get_availability(
     if not at:
         raise ValueError("Appointment type not found")
 
-    tz = ZoneInfo(tz_name)
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        tz = timezone.utc
     duration = timedelta(minutes=at.duration_minutes)
     max_per_slot = at.max_bookings_per_slot
 
@@ -79,11 +82,18 @@ def get_availability(
     d = from_date
     while d <= to_date:
         dow = d.weekday()  # Mon=0
-        day_slots: list[dict] = []
+        day_slots_map: dict[tuple, dict] = {}
 
         def add_slots_for_resource(res: Resource | None, res_id: int | None):
             for sch in schedules:
-                if sch.day_of_week != dow:
+                mode = sch.schedule_mode or "weekly"
+                if mode == "weekly":
+                    if sch.day_of_week != dow:
+                        continue
+                elif mode == "flexible":
+                    if sch.slot_date != d:
+                        continue
+                else:
                     continue
                 if sch.resource_id is not None and res_id is not None and sch.resource_id != res_id:
                     continue
@@ -102,14 +112,14 @@ def get_availability(
                     )
                     avail = max(0, max_per_slot - used)
                     if avail > 0:
-                        day_slots.append(
-                            {
+                        key = (slot_start.astimezone(timezone.utc).replace(tzinfo=timezone.utc), res_id)
+                        if key not in day_slots_map:
+                            day_slots_map[key] = {
                                 "start": slot_start,
                                 "end": slot_end,
                                 "available_capacity": avail,
                                 "resource_id": res_id,
                             }
-                        )
                     cur += duration
 
         if at.appointment_kind == "resource":
@@ -118,7 +128,7 @@ def get_availability(
         else:
             add_slots_for_resource(None, None)
 
-        day_slots.sort(key=lambda x: x["start"])
+        day_slots = sorted(day_slots_map.values(), key=lambda x: x["start"])
         if day_slots:
             days_out.append(
                 {

--- a/backend/tests/test_schedule_modes.py
+++ b/backend/tests/test_schedule_modes.py
@@ -1,0 +1,140 @@
+from datetime import date, timedelta
+from uuid import uuid4
+
+from app.models.user import User
+from app.utils.jwt import create_access_token
+from app.utils.password import hash_password
+
+
+def _auth_header(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, {"role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_organiser(db_session, email: str = "organiser-schedule@example.com") -> User:
+    user = User(
+        full_name="Schedule Organiser",
+        email=email,
+        password_hash=hash_password("password123"),
+        role="organiser",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _create_appointment(client, organiser: User, *, slot_schedule: str = "weekly") -> int:
+    payload = {
+        "name": f"Consultation-{uuid4().hex[:6]}",
+        "description": "Schedule mode test",
+        "duration_minutes": 30,
+        "appointment_kind": "user",
+        "slot_schedule": slot_schedule,
+        "is_published": True,
+        "manage_capacity": False,
+        "advance_payment": False,
+        "manual_confirmation": False,
+        "assignment_mode": "manual",
+        "max_bookings_per_slot": 1,
+    }
+    resp = client.post("/api/appointments/mine", json=payload, headers=_auth_header(organiser))
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def _next_weekday(start: date, weekday: int) -> date:
+    days_ahead = (weekday - start.weekday()) % 7
+    return start + timedelta(days=days_ahead)
+
+
+def test_weekly_schedule_availability_unchanged(client, db_session):
+    organiser = _create_organiser(db_session)
+    appointment_id = _create_appointment(client, organiser, slot_schedule="weekly")
+
+    target_day = _next_weekday(date.today() + timedelta(days=1), 2)  # Wednesday
+    schedule_payload = {
+        "day_of_week": 2,
+        "start_time": "09:00",
+        "end_time": "10:00",
+    }
+    created = client.post(
+        f"/api/appointments/mine/{appointment_id}/schedules",
+        json=schedule_payload,
+        headers=_auth_header(organiser),
+    )
+    assert created.status_code == 200
+    assert created.json()["schedule_mode"] == "weekly"
+    assert created.json()["day_of_week"] == 2
+    assert created.json()["slot_date"] is None
+
+    availability = client.get(
+        f"/api/appointments/{appointment_id}/availability"
+        f"?from_date={target_day.isoformat()}&to_date={target_day.isoformat()}&tz=UTC"
+    )
+    assert availability.status_code == 200
+    rows = availability.json()
+    assert len(rows) == 1
+    assert rows[0]["date"] == target_day.isoformat()
+    assert len(rows[0]["slots"]) == 2
+
+
+def test_flexible_schedule_availability_and_overlap_dedup(client, db_session):
+    organiser = _create_organiser(db_session, email="organiser-flex@example.com")
+    appointment_id = _create_appointment(client, organiser, slot_schedule="flexible")
+
+    target_day = date.today() + timedelta(days=3)
+
+    invalid_payload = {
+        "schedule_mode": "flexible",
+        "start_time": "10:00",
+        "end_time": "11:00",
+    }
+    invalid = client.post(
+        f"/api/appointments/mine/{appointment_id}/schedules",
+        json=invalid_payload,
+        headers=_auth_header(organiser),
+    )
+    assert invalid.status_code == 422
+
+    flexible_payload = {
+        "schedule_mode": "flexible",
+        "slot_date": target_day.isoformat(),
+        "start_time": "10:00",
+        "end_time": "11:00",
+    }
+    created_flexible = client.post(
+        f"/api/appointments/mine/{appointment_id}/schedules",
+        json=flexible_payload,
+        headers=_auth_header(organiser),
+    )
+    assert created_flexible.status_code == 200
+    assert created_flexible.json()["schedule_mode"] == "flexible"
+    assert created_flexible.json()["day_of_week"] is None
+    assert created_flexible.json()["slot_date"] == target_day.isoformat()
+
+    overlapping_weekly_payload = {
+        "schedule_mode": "weekly",
+        "day_of_week": target_day.weekday(),
+        "start_time": "10:00",
+        "end_time": "11:00",
+    }
+    created_weekly = client.post(
+        f"/api/appointments/mine/{appointment_id}/schedules",
+        json=overlapping_weekly_payload,
+        headers=_auth_header(organiser),
+    )
+    assert created_weekly.status_code == 200
+
+    availability = client.get(
+        f"/api/appointments/{appointment_id}/availability"
+        f"?from_date={target_day.isoformat()}&to_date={target_day.isoformat()}&tz=UTC"
+    )
+    assert availability.status_code == 200
+    rows = availability.json()
+    assert len(rows) == 1
+    slots = rows[0]["slots"]
+    assert len(slots) == 2
+    assert "T10:00:00" in slots[0]["start"]
+    assert "T10:30:00" in slots[1]["start"]

--- a/frontend/src/pages/organiser/AppointmentForm.jsx
+++ b/frontend/src/pages/organiser/AppointmentForm.jsx
@@ -79,7 +79,15 @@ export default function AppointmentForm() {
         <div className="p-5">
           {(isNew || tab === "basics") && <BasicsSection form={form} setForm={setForm} />}
           {!isNew && tab === "resources" && <ResourcesSection appointmentId={id} resources={at?.resources} onRefresh={refresh} />}
-          {!isNew && tab === "schedule" && <ScheduleSection appointmentId={id} schedules={at?.schedules} resources={at?.resources} onRefresh={refresh} />}
+          {!isNew && tab === "schedule" && (
+            <ScheduleSection
+              appointmentId={id}
+              slotSchedule={at?.slot_schedule}
+              schedules={at?.schedules}
+              resources={at?.resources}
+              onRefresh={refresh}
+            />
+          )}
           {!isNew && tab === "rules" && <RulesSection form={form} setForm={setForm} />}
           {!isNew && tab === "questions" && <QuestionsSection appointmentId={id} questions={at?.questions} onRefresh={refresh} />}
           {!isNew && tab === "preview" && (

--- a/frontend/src/pages/organiser/appointment/ScheduleSection.jsx
+++ b/frontend/src/pages/organiser/appointment/ScheduleSection.jsx
@@ -8,17 +8,47 @@ import { api } from "../../../services/api.js";
 const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 const SHORT = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-export default function ScheduleSection({ appointmentId, schedules, resources, onRefresh }) {
-  const [sch, setSch] = useState({ day_of_week: 0, start_time: "09:00", end_time: "17:00", resource_id: null });
+export default function ScheduleSection({ appointmentId, slotSchedule, schedules, resources, onRefresh }) {
+  const [sch, setSch] = useState({
+    schedule_mode: slotSchedule || "weekly",
+    day_of_week: 0,
+    slot_date: "",
+    start_time: "09:00",
+    end_time: "17:00",
+    resource_id: null,
+  });
 
   async function add(e) {
     e.preventDefault();
+    const payload = {
+      schedule_mode: sch.schedule_mode,
+      resource_id: sch.resource_id || null,
+      start_time: sch.start_time,
+      end_time: sch.end_time,
+      day_of_week: sch.schedule_mode === "weekly" ? sch.day_of_week : null,
+      slot_date: sch.schedule_mode === "flexible" ? sch.slot_date : null,
+    };
     await api(`/api/appointments/mine/${appointmentId}/schedules`, {
       method: "POST",
-      body: JSON.stringify({ ...sch, resource_id: sch.resource_id || null }),
+      body: JSON.stringify(payload),
     });
+    setSch((prev) => ({
+      ...prev,
+      slot_date: "",
+      day_of_week: 0,
+      start_time: "09:00",
+      end_time: "17:00",
+      resource_id: null,
+    }));
     onRefresh();
   }
+
+  async function removeSchedule(id) {
+    await api(`/api/appointments/mine/${appointmentId}/schedules/${id}`, { method: "DELETE" });
+    onRefresh();
+  }
+
+  const mode = sch.schedule_mode;
 
   return (
     <div className="space-y-4">
@@ -28,19 +58,31 @@ export default function ScheduleSection({ appointmentId, schedules, resources, o
           <table className="w-full text-left text-sm">
             <thead className="border-b border-outline-variant bg-surface-container-low">
               <tr>
-                <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Day</th>
+                <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Mode</th>
+                <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Day / Date</th>
                 <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Start</th>
                 <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">End</th>
                 <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Resource</th>
+                <th className="px-3 py-2 text-xs font-semibold uppercase text-on-surface-variant">Action</th>
               </tr>
             </thead>
             <tbody>
               {schedules.map((s) => (
                 <tr key={s.id} className="border-b border-outline-variant last:border-0 hover:bg-surface-container-low/50">
-                  <td className="px-3 py-2 font-medium">{SHORT[s.day_of_week]}</td>
+                  <td className="px-3 py-2 font-medium capitalize">{s.schedule_mode || "weekly"}</td>
+                  <td className="px-3 py-2 font-medium">
+                    {s.schedule_mode === "flexible"
+                      ? (s.slot_date || "-")
+                      : (s.day_of_week != null ? SHORT[s.day_of_week] : "-")}
+                  </td>
                   <td className="px-3 py-2">{s.start_time}</td>
                   <td className="px-3 py-2">{s.end_time}</td>
                   <td className="px-3 py-2 text-on-surface-variant">{s.resource_id ? `#${s.resource_id}` : "All"}</td>
+                  <td className="px-3 py-2">
+                    <Button variant="ghost" className="p-2" onClick={() => removeSchedule(s.id)}>
+                      <Trash2 size={14} />
+                    </Button>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -51,12 +93,20 @@ export default function ScheduleSection({ appointmentId, schedules, resources, o
       {/* Add new schedule */}
       <form onSubmit={add} className="rounded-lg border border-dashed border-outline-variant bg-surface-container-low/40 p-4">
         <p className="mb-3 text-xs font-bold uppercase text-on-surface-variant">Add time window</p>
-        <div className="grid gap-3 sm:grid-cols-4">
-          <Select label="Day" value={sch.day_of_week} onChange={(e) => setSch((s) => ({ ...s, day_of_week: Number(e.target.value) }))}>
-            {DAYS.map((d, i) => <option key={d} value={i}>{d}</option>)}
+        <div className="grid gap-3 sm:grid-cols-5">
+          <Select label="Mode" value={sch.schedule_mode} onChange={(e) => setSch((s) => ({ ...s, schedule_mode: e.target.value }))}>
+            <option value="weekly">Weekly</option>
+            <option value="flexible">Flexible</option>
           </Select>
-          <Input label="Start" value={sch.start_time} onChange={(e) => setSch((s) => ({ ...s, start_time: e.target.value }))} />
-          <Input label="End" value={sch.end_time} onChange={(e) => setSch((s) => ({ ...s, end_time: e.target.value }))} />
+          {mode === "weekly" ? (
+            <Select label="Day" value={sch.day_of_week} onChange={(e) => setSch((s) => ({ ...s, day_of_week: Number(e.target.value) }))}>
+              {DAYS.map((d, i) => <option key={d} value={i}>{d}</option>)}
+            </Select>
+          ) : (
+            <Input type="date" label="Date" value={sch.slot_date} onChange={(e) => setSch((s) => ({ ...s, slot_date: e.target.value }))} required />
+          )}
+          <Input type="time" label="Start" value={sch.start_time} onChange={(e) => setSch((s) => ({ ...s, start_time: e.target.value }))} required />
+          <Input type="time" label="End" value={sch.end_time} onChange={(e) => setSch((s) => ({ ...s, end_time: e.target.value }))} required />
           <Select label="Resource" value={sch.resource_id || ""} onChange={(e) => setSch((s) => ({ ...s, resource_id: e.target.value ? Number(e.target.value) : null }))}>
             <option value="">All / type-level</option>
             {resources?.map((r) => <option key={r.id} value={r.id}>{r.name}</option>)}


### PR DESCRIPTION
## Summary\n- implement dual schedule modes (weekly + flexible) in backend model, schema, and APIs\n- update availability engine to correctly merge weekly and date-specific flexible slots\n- add organiser UI support for creating and managing flexible slots\n- add migration + tests covering schedule modes and overlap edge cases\n\n## Validation\n- uv run pytest tests/test_schedule_modes.py tests/test_booking_lifecycle_and_reports.py\n\nCloses #5