### PR TITLE
fix: use interval overlap for capacity checks instead of exact start_…

### DIFF
--- a/backend/app/services/availability.py
+++ b/backend/app/services/availability.py
@@ -1,6 +1,5 @@
 """Compute available booking slots from weekly schedules minus existing bookings."""
 
-from collections import defaultdict
 from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
@@ -66,13 +65,19 @@ def get_availability(
         bookings_q = bookings_q.where(Booking.resource_id == resource_id)
     bookings = db.execute(bookings_q).scalars().all()
 
-    def slot_usage_key(start: datetime, res_id: int | None) -> tuple:
-        return (start.astimezone(timezone.utc).replace(tzinfo=timezone.utc), res_id)
-
-    usage: dict[tuple, int] = defaultdict(int)
-    for b in bookings:
-        key = slot_usage_key(b.start_time, b.resource_id)
-        usage[key] += b.capacity
+    def _overlap_usage(slot_start: datetime, slot_end: datetime, res_id: int | None) -> int:
+        """Sum capacity of bookings whose interval overlaps [slot_start, slot_end)."""
+        total = 0
+        ss_utc = slot_start.astimezone(timezone.utc)
+        se_utc = slot_end.astimezone(timezone.utc)
+        for b in bookings:
+            if res_id is not None and b.resource_id != res_id:
+                continue
+            b_start = b.start_time if b.start_time.tzinfo else b.start_time.replace(tzinfo=timezone.utc)
+            b_end = b.end_time if b.end_time.tzinfo else b.end_time.replace(tzinfo=timezone.utc)
+            if b_start < se_utc and b_end > ss_utc:
+                total += b.capacity
+        return total
 
     days_out: list[dict] = []
     d = from_date
@@ -95,10 +100,7 @@ def get_availability(
                 while cur + duration <= end:
                     slot_start = cur
                     slot_end = cur + duration
-                    used = usage.get(
-                        (slot_start.astimezone(timezone.utc).replace(tzinfo=timezone.utc), res_id),
-                        0,
-                    )
+                    used = _overlap_usage(slot_start, slot_end, res_id)
                     avail = max(0, max_per_slot - used)
                     if avail > 0:
                         day_slots.append(

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -44,7 +44,8 @@ def create_booking(
             Booking.appointment_type_id == appointment_type_id,
             Booking.resource_id == resource_id,
             Booking.status.in_(["pending", "confirmed"]),
-            Booking.start_time == start_time,
+            Booking.start_time < end_time,
+            Booking.end_time > start_time,
         )
     ).scalar_one()
 
@@ -114,7 +115,8 @@ def reschedule_booking(db: Session, booking_id: int, user_id: int, new_start: da
             Booking.appointment_type_id == b.appointment_type_id,
             Booking.resource_id == b.resource_id,
             Booking.status.in_(["pending", "confirmed"]),
-            Booking.start_time == new_start,
+            Booking.start_time < end_time,
+            Booking.end_time > new_start,
             Booking.id != b.id,
         )
     ).scalar_one()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "email-validator>=2.2.0",
     "python-multipart>=0.0.17",
+    "tzdata>=2026.2",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/tests/test_booking_overlap.py
+++ b/backend/tests/test_booking_overlap.py
@@ -1,0 +1,198 @@
+"""Tests for interval-overlap capacity enforcement in booking_service.
+
+Covers:
+  - Same start time → reject when capacity full
+  - Shifted overlap (different start, intervals overlap) → reject
+  - Boundary touching (end == start of next) → allow
+  - Non-overlapping same day → allow
+  - Reschedule into overlapping slot → reject
+  - Reschedule into non-overlapping slot → allow
+  - Cancelled booking frees capacity for overlap window
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.appointment_type import AppointmentType
+from app.models.booking import Booking
+from app.models.user import User
+from app.services import booking_service
+from app.utils.password import hash_password
+
+
+UTC = timezone.utc
+BASE = datetime(2025, 6, 15, 10, 0, tzinfo=UTC)
+
+
+def _setup(db, *, max_bookings=1, duration=60, kind="user"):
+    """Create an organiser, a customer, and a published appointment type."""
+    organiser = User(
+        full_name="Org", email="org@test.com",
+        password_hash=hash_password("x"), role="organiser", is_active=True,
+    )
+    customer = User(
+        full_name="Cust", email="cust@test.com",
+        password_hash=hash_password("x"), role="customer", is_active=True,
+    )
+    db.add_all([organiser, customer])
+    db.flush()
+
+    at = AppointmentType(
+        organiser_id=organiser.id,
+        name="Test",
+        duration_minutes=duration,
+        appointment_kind=kind,
+        is_published=True,
+        manage_capacity=True,
+        max_bookings_per_slot=max_bookings,
+    )
+    db.add(at)
+    db.flush()
+    return customer, at
+
+
+# ── create_booking overlap tests ──────────────────────────────────────
+
+
+def test_same_start_rejects_when_full(db_session):
+    """Two bookings at exact same start_time exceed capacity=1."""
+    cust, at = _setup(db_session)
+
+    booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    with pytest.raises(ValueError, match="capacity"):
+        booking_service.create_booking(
+            db_session, cust.id, at.id, None, BASE, 1, None,
+        )
+
+
+def test_shifted_overlap_rejects(db_session):
+    """Booking shifted 30 min still overlaps a 60-min slot → reject."""
+    cust, at = _setup(db_session, duration=60)
+
+    booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    # Starts 30 min later; overlaps [10:00–11:00] with [10:30–11:30]
+    with pytest.raises(ValueError, match="capacity"):
+        booking_service.create_booking(
+            db_session, cust.id, at.id, None, BASE + timedelta(minutes=30), 1, None,
+        )
+
+
+def test_boundary_touching_allowed(db_session):
+    """Booking starting exactly when previous ends is NOT overlapping."""
+    cust, at = _setup(db_session, duration=60)
+
+    booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    # Starts at 11:00, right when the first ends → no overlap
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(minutes=60), 1, None,
+    )
+    assert b2.start_time.replace(tzinfo=None) == (BASE + timedelta(minutes=60)).replace(tzinfo=None)
+
+
+def test_non_overlapping_same_day_allowed(db_session):
+    """Two bookings hours apart on the same day are fine."""
+    cust, at = _setup(db_session, duration=30)
+
+    booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(hours=3), 1, None,
+    )
+    assert b2 is not None
+
+
+def test_overlap_allowed_when_capacity_permits(db_session):
+    """With max_bookings=2 two overlapping bookings should be accepted."""
+    cust, at = _setup(db_session, max_bookings=2, duration=60)
+
+    booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(minutes=15), 1, None,
+    )
+    assert b2 is not None
+
+    # Third should fail
+    with pytest.raises(ValueError, match="capacity"):
+        booking_service.create_booking(
+            db_session, cust.id, at.id, None, BASE + timedelta(minutes=30), 1, None,
+        )
+
+
+# ── reschedule overlap tests ─────────────────────────────────────────
+
+
+def test_reschedule_into_overlap_rejects(db_session):
+    """Rescheduling a booking into a slot that overlaps an existing one is rejected."""
+    cust, at = _setup(db_session, duration=60)
+
+    b1 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(hours=3), 1, None,
+    )
+    # Move b2 to overlap with b1
+    with pytest.raises(ValueError, match="capacity"):
+        booking_service.reschedule_booking(
+            db_session, b2.id, cust.id, BASE + timedelta(minutes=30),
+        )
+
+
+def test_reschedule_into_non_overlapping_allowed(db_session):
+    """Rescheduling to a free slot succeeds."""
+    cust, at = _setup(db_session, duration=60)
+
+    b1 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(hours=3), 1, None,
+    )
+    # Move b2 to a non-overlapping time
+    updated = booking_service.reschedule_booking(
+        db_session, b2.id, cust.id, BASE + timedelta(hours=5),
+    )
+    assert updated.start_time.replace(tzinfo=None) == (BASE + timedelta(hours=5)).replace(tzinfo=None)
+
+
+def test_reschedule_same_slot_allowed(db_session):
+    """Rescheduling a booking to its own current time should succeed (self-overlap excluded)."""
+    cust, at = _setup(db_session, duration=60)
+
+    b = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    updated = booking_service.reschedule_booking(
+        db_session, b.id, cust.id, BASE,
+    )
+    assert updated.start_time.replace(tzinfo=None) == BASE.replace(tzinfo=None)
+
+
+# ── cancelled booking frees capacity ─────────────────────────────────
+
+
+def test_cancelled_booking_frees_overlap_capacity(db_session):
+    """After cancelling a booking, a new overlapping one should be accepted."""
+    cust, at = _setup(db_session, duration=60)
+
+    b1 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE, 1, None,
+    )
+    # Cancel b1
+    booking_service.cancel_booking(db_session, b1.id, cust.id, "customer")
+
+    # Now an overlapping booking should succeed
+    b2 = booking_service.create_booking(
+        db_session, cust.id, at.id, None, BASE + timedelta(minutes=15), 1, None,
+    )
+    assert b2 is not None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,6 +1018,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1093,6 +1102,7 @@ dependencies = [
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1114,6 +1124,7 @@ requires-dist = [
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.17" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "tzdata", specifier = ">=2026.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 

--- a/frontend/src/pages/customer/BookingFlow.jsx
+++ b/frontend/src/pages/customer/BookingFlow.jsx
@@ -45,8 +45,10 @@ export default function BookingFlow() {
 
   useEffect(() => {
     if (step !== 3 || !date || !at || !fromTo) return;
-    const rid = at.appointment_kind === "resource" ? resourceId : "";
-    api(`/api/appointments/${id}/availability?from_date=${fromTo.from}&to_date=${fromTo.to}&resource_id=${rid || ""}&tz=UTC`)
+    const rid = at.appointment_kind === "resource" ? resourceId : null;
+    const params = new URLSearchParams({ from_date: fromTo.from, to_date: fromTo.to, tz: "UTC" });
+    if (rid) params.set("resource_id", rid);
+    api(`/api/appointments/${id}/availability?${params}`)
       .then(setAvailability)
       .catch((e) => setErr(e.message));
   }, [step, date, resourceId, id, at, fromTo]);


### PR DESCRIPTION
…time

- booking_service.py: capacity sum queries now use start_time < end_time AND end_time > start_time for both create and reschedule flows
- availability.py: slot usage calculation uses overlap instead of exact match
- BookingFlow.jsx: omit empty resource_id from availability query to fix 422
- Added tzdata dependency for Windows timezone support
- Added 9 tests covering overlap edge cases