### PR TITLE
feat: add embeddable booking widget support

### DIFF
--- a/backend/tests/test_visibility_modes.py
+++ b/backend/tests/test_visibility_modes.py
@@ -149,3 +149,38 @@ def test_visibility_defaults_to_public_on_create(client, db_session):
     created = client.post("/api/appointments/mine", json=payload, headers=_auth_header(organiser))
     assert created.status_code == 200
     assert created.json()["visibility"] == "public"
+
+
+def test_embed_share_path_lookup_and_booking_submission(client, db_session):
+    organiser = _create_user(db_session, "org-vis-embed@example.com", "organiser")
+    customer = _create_user(db_session, "customer-vis-embed@example.com", "customer")
+    unlisted_appt = _create_appointment(db_session, organiser.id, visibility="unlisted", is_published=True)
+
+    slot_start = (datetime.now(timezone.utc) + timedelta(days=1)).replace(minute=0, second=0, microsecond=0)
+    db_session.add(
+        Schedule(
+            appointment_type_id=unlisted_appt.id,
+            resource_id=None,
+            schedule_mode="weekly",
+            day_of_week=slot_start.weekday(),
+            slot_date=None,
+            start_time=slot_start.time(),
+            end_time=(slot_start + timedelta(minutes=30)).time(),
+        )
+    )
+    db_session.commit()
+
+    lookup = client.get(f"/api/appointments/by-share/{unlisted_appt.share_link}")
+    assert lookup.status_code == 200
+    assert lookup.json()["id"] == unlisted_appt.id
+
+    booking_payload = {
+        "appointment_type_id": unlisted_appt.id,
+        "resource_id": None,
+        "start_time": slot_start.isoformat(),
+        "capacity": 1,
+        "answers": None,
+        "share_token": unlisted_appt.share_link,
+    }
+    booked = client.post("/api/bookings", json=booking_payload, headers=_auth_header(customer))
+    assert booked.status_code == 200

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import VerifyOtp from "./pages/auth/VerifyOtp.jsx";
 import ForgotPassword from "./pages/auth/ForgotPassword.jsx";
 import Home from "./pages/customer/Home.jsx";
 import BookingFlow from "./pages/customer/BookingFlow.jsx";
+import EmbedBookingPage from "./pages/customer/EmbedBookingPage.jsx";
 import Profile from "./pages/customer/Profile.jsx";
 import Dashboard from "./pages/organiser/Dashboard.jsx";
 import AppointmentList from "./pages/organiser/AppointmentList.jsx";
@@ -75,7 +76,6 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/book/share/:token" element={<BookingFlow />} />
         <Route path="/book/:id" element={<BookingFlow />} />
-        <Route path="/book/share/:shareLink" element={<BookingFlow />} />
         <Route
           path="/profile"
           element={
@@ -85,6 +85,8 @@ export default function App() {
           }
         />
       </Route>
+
+      <Route path="/embed/book/share/:token" element={<EmbedBookingPage />} />
 
       <Route path="/app" element={<OrganiserShell />}>
         <Route index element={<Dashboard />} />

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,7 +7,7 @@ import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <AuthProvider>
         <App />
       </AuthProvider>

--- a/frontend/src/pages/customer/EmbedBookingPage.jsx
+++ b/frontend/src/pages/customer/EmbedBookingPage.jsx
@@ -1,0 +1,9 @@
+import BookingFlow from "./BookingFlow.jsx";
+
+export default function EmbedBookingPage() {
+  return (
+    <div className="min-h-screen bg-surface p-3 sm:p-4">
+      <BookingFlow />
+    </div>
+  );
+}

--- a/frontend/src/pages/organiser/AppointmentForm.jsx
+++ b/frontend/src/pages/organiser/AppointmentForm.jsx
@@ -24,12 +24,21 @@ const TABS = [
 
 export default function AppointmentForm() {
   const { id } = useParams();
-  const { isNew, form, setForm, at, setAt: refresh, err, saveBase } = useAppointment(id);
+  const { isNew, form, setForm, at, setAt: refresh, err, saveBase, loading, notFound } = useAppointment(id);
   const [tab, setTab] = useState("basics");
   const previewHref = !isNew && at?.share_link && form.visibility === "unlisted" ? `/book/share/${at.share_link}` : `/book/${id}`;
+  const embedUrl = at?.share_link ? `${window.location.origin}/embed/book/share/${encodeURIComponent(at.share_link)}` : "";
+  const iframeSnippet = embedUrl
+    ? `<iframe src="${embedUrl}" width="100%" height="760" style="border:0;" loading="lazy" title="Book appointment"></iframe>`
+    : "";
+  const jsSnippet = embedUrl
+    ? `<div id="neubook-widget"></div><script>(function(){var f=document.createElement('iframe');f.src='${embedUrl}';f.style.width='100%';f.style.height='760px';f.style.border='0';f.loading='lazy';f.title='Book appointment';document.getElementById('neubook-widget').appendChild(f);})();</script>`
+    : "";
   const [copied, setCopied] = useState(false);
+  const [copiedEmbed, setCopiedEmbed] = useState("");
 
-  if (!isNew && !at) return <p className="p-8 text-on-surface-variant">Loading…</p>;
+  if (!isNew && loading) return <p className="p-8 text-on-surface-variant">Loading…</p>;
+  if (!isNew && notFound) return <p className="p-8 text-error">Appointment not found or inaccessible.</p>;
 
   async function togglePublish() {
     setForm((f) => ({ ...f, is_published: !f.is_published }));
@@ -39,6 +48,18 @@ export default function AppointmentForm() {
         body: JSON.stringify({ is_published: !form.is_published }),
       });
       refresh();
+    }
+  }
+
+  async function copyEmbed(kind) {
+    const text = kind === "iframe" ? iframeSnippet : jsSnippet;
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedEmbed(kind);
+      setTimeout(() => setCopiedEmbed(""), 1500);
+    } catch {
+      setCopiedEmbed("");
     }
   }
 
@@ -127,6 +148,26 @@ export default function AppointmentForm() {
               <Link to={previewHref} target="_blank">
                 <Button className="gap-1 mt-2"><ExternalLink size={16} /> Open booking flow</Button>
               </Link>
+              {at.share_link && (
+                <div className="mt-4 space-y-3 rounded-lg border border-outline-variant bg-surface-container-lowest p-3">
+                  <p className="text-sm font-semibold text-on-surface">Embed widget</p>
+                  <p className="text-xs text-on-surface-variant">Paste one of these snippets into your website to embed the booking flow.</p>
+                  <div>
+                    <div className="mb-1 flex items-center justify-between">
+                      <p className="text-xs font-semibold uppercase text-on-surface-variant">Iframe snippet</p>
+                      <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => copyEmbed("iframe")}>{copiedEmbed === "iframe" ? "Copied" : "Copy"}</Button>
+                    </div>
+                    <textarea readOnly value={iframeSnippet} className="h-20 w-full rounded-lg border border-outline-variant bg-surface-container-low p-2 text-xs text-on-surface-variant" />
+                  </div>
+                  <div>
+                    <div className="mb-1 flex items-center justify-between">
+                      <p className="text-xs font-semibold uppercase text-on-surface-variant">JS snippet</p>
+                      <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => copyEmbed("js")}>{copiedEmbed === "js" ? "Copied" : "Copy"}</Button>
+                    </div>
+                    <textarea readOnly value={jsSnippet} className="h-24 w-full rounded-lg border border-outline-variant bg-surface-container-low p-2 text-xs text-on-surface-variant" />
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/organiser/appointment/useAppointment.js
+++ b/frontend/src/pages/organiser/appointment/useAppointment.js
@@ -23,17 +23,30 @@ export function useAppointment(id) {
   const [form, setForm] = useState({ ...defaultForm });
   const [at, setAt] = useState(null);
   const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(!isNew);
+  const [notFound, setNotFound] = useState(false);
 
   function refresh() {
+    if (!isNew) setLoading(true);
     return api("/api/appointments/mine").then((rows) => {
       const found = rows.find((x) => String(x.id) === String(id));
       setAt(found || null);
+      setNotFound(!found);
+      setLoading(false);
       return found;
+    }).catch((ex) => {
+      setErr(ex.message || "Failed to load appointment");
+      setLoading(false);
+      throw ex;
     });
   }
 
   useEffect(() => {
-    if (isNew) return;
+    if (isNew) {
+      setLoading(false);
+      setNotFound(false);
+      return;
+    }
     refresh().then((found) => {
       if (found) {
         setForm({
@@ -71,5 +84,5 @@ export function useAppointment(id) {
     }
   }
 
-  return { isNew, form, setForm, at, setAt: refresh, err, setErr, saveBase };
+  return { isNew, form, setForm, at, setAt: refresh, err, setErr, saveBase, loading, notFound };
 }


### PR DESCRIPTION
## Summary
- add dedicated embeddable booking entrypoint at /embed/book/share/:token
- add organiser embed snippets (iframe + JS) with copy actions in appointment preview
- keep share-link and visibility rules enforced in embedded booking flow
- improve appointment editor loading/not-found handling to avoid infinite loading state
- enable React Router future flags for v7 compatibility warnings
- add backend test coverage for share-link embed lookup and booking submission path

## Validation
- uv run pytest tests/test_visibility_modes.py tests/test_booking_lifecycle_and_reports.py
- npm run build

Closes #24