### PR TITLE
feat: private provider notes & customer tags

### DIFF
--- a/backend/alembic/versions/012_provider_notes_and_customer_tags.py
+++ b/backend/alembic/versions/012_provider_notes_and_customer_tags.py
@@ -1,0 +1,58 @@
+"""provider_notes_and_customer_tags
+
+Revision ID: 012
+Revises: 011_waitlist
+Create Date: 2026-05-03 03:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '012'
+down_revision: Union[str, None] = '011'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'provider_notes',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('provider_id', sa.Integer(), nullable=False),
+        sa.Column('customer_id', sa.Integer(), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['provider_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['customer_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('ix_provider_notes_provider_id', 'provider_notes', ['provider_id'])
+    op.create_index('ix_provider_notes_customer_id', 'provider_notes', ['customer_id'])
+
+    op.create_table(
+        'customer_tags',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('provider_id', sa.Integer(), nullable=False),
+        sa.Column('customer_id', sa.Integer(), nullable=False),
+        sa.Column('label', sa.String(length=64), nullable=False),
+        sa.Column('color', sa.String(length=7), nullable=False, server_default='#e5e7eb'),
+        sa.Column('is_system_suggested', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['provider_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['customer_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('ix_customer_tags_provider_id', 'customer_tags', ['provider_id'])
+    op.create_index('ix_customer_tags_customer_id', 'customer_tags', ['customer_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_customer_tags_customer_id', table_name='customer_tags')
+    op.drop_index('ix_customer_tags_provider_id', table_name='customer_tags')
+    op.drop_table('customer_tags')
+    op.drop_index('ix_provider_notes_customer_id', table_name='provider_notes')
+    op.drop_index('ix_provider_notes_provider_id', table_name='provider_notes')
+    op.drop_table('provider_notes')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.routers import appointments, auth, bookings, reports, users, waitlist
+from app.routers import appointments, auth, bookings, provider_notes, reports, users, waitlist
 
 app = FastAPI(title="Neubook API", version="0.1.0")
 
@@ -21,6 +21,7 @@ app.include_router(bookings.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
 app.include_router(reports.router, prefix="/api")
 app.include_router(waitlist.router, prefix="/api")
+app.include_router(provider_notes.router, prefix="/api")
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,8 @@ from app.models.booking_seat import BookingSeat
 from app.models.auth_tokens import EmailOTP, PasswordResetToken
 from app.models.idempotency import IdempotencyRecord
 from app.models.waitlist import WaitlistEntry
+from app.models.provider_note import ProviderNote
+from app.models.customer_tag import CustomerTag
 
 __all__ = [
     "User",
@@ -27,4 +29,6 @@ __all__ = [
     "PasswordResetToken",
     "IdempotencyRecord",
     "WaitlistEntry",
+    "ProviderNote",
+    "CustomerTag",
 ]

--- a/backend/app/models/customer_tag.py
+++ b/backend/app/models/customer_tag.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class CustomerTag(Base):
+    __tablename__ = "customer_tags"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    provider_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    customer_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    label: Mapped[str] = mapped_column(String(64), nullable=False)
+    color: Mapped[str] = mapped_column(String(7), nullable=False, default="#e5e7eb")
+    is_system_suggested: Mapped[bool] = mapped_column(
+        nullable=False, default=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/app/models/provider_note.py
+++ b/backend/app/models/provider_note.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ProviderNote(Base):
+    __tablename__ = "provider_notes"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    provider_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    customer_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/app/routers/provider_notes.py
+++ b/backend/app/routers/provider_notes.py
@@ -1,0 +1,118 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import desc, select
+from app.deps import CurrentUser, DBSession, require_roles
+from app.models.customer_tag import CustomerTag
+from app.models.provider_note import ProviderNote
+from app.schemas.customer_tag import CustomerTagCreate, CustomerTagOut
+from app.schemas.provider_note import ProviderNoteCreate, ProviderNoteOut
+
+router = APIRouter(prefix="/provider-notes", tags=["Provider Notes"])
+
+# ─── Notes ───
+
+@router.get("/notes/{customer_id}", response_model=list[ProviderNoteOut])
+def list_notes(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    customer_id: int,
+):
+    q = (
+        select(ProviderNote)
+        .where(
+            ProviderNote.provider_id == user.id,
+            ProviderNote.customer_id == customer_id,
+        )
+        .order_by(ProviderNote.created_at.asc())
+    )
+    rows = db.execute(q).scalars().all()
+    return rows
+
+
+@router.post("/notes", response_model=ProviderNoteOut)
+def create_note(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    body: ProviderNoteCreate,
+):
+    note = ProviderNote(
+        provider_id=user.id,
+        customer_id=body.customer_id,
+        content=body.content,
+    )
+    db.add(note)
+    db.commit()
+    db.refresh(note)
+    return note
+
+
+@router.get("/notes/search", response_model=list[ProviderNoteOut])
+def search_notes(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    q: str,
+):
+    q_lower = f"%{q.lower()}%"
+    stmt = (
+        select(ProviderNote)
+        .where(
+            ProviderNote.provider_id == user.id,
+            ProviderNote.content.ilike(q_lower),
+        )
+        .order_by(desc(ProviderNote.created_at))
+    )
+    rows = db.execute(stmt).scalars().all()
+    return rows
+
+
+# ─── Tags ───
+
+@router.get("/tags/{customer_id}", response_model=list[CustomerTagOut])
+def list_tags(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    customer_id: int,
+):
+    q = (
+        select(CustomerTag)
+        .where(
+            CustomerTag.provider_id == user.id,
+            CustomerTag.customer_id == customer_id,
+        )
+        .order_by(CustomerTag.created_at.desc())
+    )
+    rows = db.execute(q).scalars().all()
+    return rows
+
+
+@router.post("/tags", response_model=CustomerTagOut)
+def create_tag(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    body: CustomerTagCreate,
+):
+    tag = CustomerTag(
+        provider_id=user.id,
+        customer_id=body.customer_id,
+        label=body.label,
+        color=body.color or "#e5e7eb",
+        is_system_suggested=body.is_system_suggested,
+    )
+    db.add(tag)
+    db.commit()
+    db.refresh(tag)
+    return tag
+
+
+@router.delete("/tags/{tag_id}")
+def delete_tag(
+    db: DBSession,
+    user: Annotated[CurrentUser, Depends(require_roles("organiser", "admin"))],
+    tag_id: int,
+):
+    tag = db.get(CustomerTag, tag_id)
+    if not tag or tag.provider_id != user.id:
+        raise HTTPException(404, "Tag not found")
+    db.delete(tag)
+    db.commit()
+    return {"ok": True}

--- a/backend/app/schemas/customer_tag.py
+++ b/backend/app/schemas/customer_tag.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class CustomerTagCreate(BaseModel):
+    customer_id: int
+    label: str
+    color: str | None = "#e5e7eb"
+    is_system_suggested: bool = False
+
+
+class CustomerTagOut(BaseModel):
+    id: int
+    provider_id: int
+    customer_id: int
+    label: str
+    color: str
+    is_system_suggested: bool
+    created_at: datetime | None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/provider_note.py
+++ b/backend/app/schemas/provider_note.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ProviderNoteCreate(BaseModel):
+    customer_id: int
+    content: str
+
+
+class ProviderNoteOut(BaseModel):
+    id: int
+    provider_id: int
+    customer_id: int
+    content: str
+    created_at: datetime | None
+
+    model_config = {"from_attributes": True}

--- a/frontend/src/components/provider/CustomerTags.jsx
+++ b/frontend/src/components/provider/CustomerTags.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useState, useRef } from "react";
+import { Tag, X, Plus, Lock } from "lucide-react";
+import { api } from "../../services/api.js";
+
+const SUGGESTED_TAGS = [
+  { label: "Frequent", color: "#10b981" },
+  { label: "Late canceller", color: "#ef4444" },
+  { label: "New customer", color: "#3b82f6" },
+  { label: "VIP", color: "#f59e0b" },
+  { label: "Referred", color: "#8b5cf6" },
+  { label: "Sensitive", color: "#ec4899" },
+];
+
+export function CustomerTags({ customerId }) {
+  const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [showInput, setShowInput] = useState(false);
+  const [input, setInput] = useState("");
+  const inputRef = useRef(null);
+
+  async function load() {
+    if (!customerId) return;
+    setLoading(true);
+    try {
+      const data = await api(`/api/provider-notes/tags/${customerId}`);
+      setTags(data || []);
+    } catch (e) {
+      setTags([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [customerId]);
+
+  useEffect(() => {
+    if (showInput && inputRef.current) inputRef.current.focus();
+  }, [showInput]);
+
+  async function addTag(label, color) {
+    if (!customerId) return;
+    try {
+      await api("/api/provider-notes/tags", {
+        method: "POST",
+        body: { customer_id: customerId, label, color },
+      });
+      setInput("");
+      setShowInput(false);
+      await load();
+    } catch (e) {
+      alert(e.message);
+    }
+  }
+
+  async function removeTag(id) {
+    if (!confirm("Remove this tag?")) return;
+    try {
+      await api(`/api/provider-notes/tags/${id}`, { method: "DELETE" });
+      await load();
+    } catch (e) {
+      alert(e.message);
+    }
+  }
+
+  const existingLabels = new Set(tags.map((t) => t.label.toLowerCase()));
+
+  return (
+    <div className="rounded-lg border border-outline-variant bg-surface-container-lowest shadow-card overflow-hidden">
+      <div className="flex items-center justify-between border-b border-outline-variant bg-surface-container-high px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Tag className="h-3.5 w-3.5 text-on-surface-variant" />
+          <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">Tags</span>
+        </div>
+        <div className="flex items-center gap-1 text-[10px] text-on-surface-variant">
+          <Lock className="h-3 w-3" />
+          <span>Private</span>
+        </div>
+      </div>
+
+      <div className="px-4 py-3 flex flex-wrap gap-2">
+        {loading && <span className="text-xs text-on-surface-variant">Loading...</span>}
+        {!loading && tags.length === 0 && !showInput && (
+          <span className="text-xs text-on-surface-variant/60 italic">No tags yet.</span>
+        )}
+
+        {tags.map((t) => (
+          <span
+            key={t.id}
+            className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:opacity-80 transition select-none"
+            style={{ backgroundColor: t.color || "#e5e7eb" }}
+            title="Click to remove"
+            onClick={() => removeTag(t.id)}
+          >
+            {t.label}
+            <X className="h-3 w-3" />
+          </span>
+        ))}
+
+        {showInput ? (
+          <div className="w-full mt-1 space-y-2">
+            <div className="flex gap-2">
+              <input
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="New tag name..."
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && input.trim()) {
+                    const existing = SUGGESTED_TAGS.find((s) => s.label.toLowerCase() === input.trim().toLowerCase());
+                    addTag(input.trim(), existing?.color || "#e5e7eb");
+                  }
+                  if (e.key === "Escape") { setShowInput(false); setInput(""); }
+                }}
+                className="flex-1 rounded-md border border-outline-variant bg-surface px-2 py-1 text-xs text-on-surface outline-none focus:ring-1 focus:ring-primary-container"
+              />
+              <button
+                onClick={() => addTag(input.trim(), "#e5e7eb")}
+                disabled={!input.trim()}
+                className="rounded-md bg-primary-container px-2 py-1 text-on-primary text-xs font-semibold disabled:opacity-40 hover:bg-primary transition"
+              >
+                Add
+              </button>
+              <button onClick={() => { setShowInput(false); setInput(""); }} className="text-on-surface-variant hover:text-on-surface">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {SUGGESTED_TAGS.filter((s) => !existingLabels.has(s.label.toLowerCase())).map((s) => (
+                <button
+                  key={s.label}
+                  onClick={() => addTag(s.label, s.color)}
+                  className="rounded-full px-2 py-0.5 text-[10px] font-medium text-white hover:opacity-80 transition"
+                  style={{ backgroundColor: s.color }}
+                >
+                  + {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowInput(true)}
+            className="inline-flex items-center gap-1 rounded-full border border-outline-variant px-2.5 py-1 text-xs text-on-surface-variant hover:bg-surface-container-low transition"
+          >
+            <Plus className="h-3 w-3" />
+            Add tag
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/provider/ProviderNotesPanel.jsx
+++ b/frontend/src/components/provider/ProviderNotesPanel.jsx
@@ -1,0 +1,160 @@
+import { useEffect, useState, useRef } from "react";
+import { Lock, Send, Search, X } from "lucide-react";
+import { api } from "../../services/api.js";
+
+function formatDateLabel(d) {
+  const now = new Date();
+  const date = new Date(d);
+  const isToday = now.toDateString() === date.toDateString();
+  const isYesterday = new Date(now.getTime() - 86400000).toDateString() === date.toDateString();
+  if (isToday) return "Today";
+  if (isYesterday) return "Yesterday";
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatTime(d) {
+  return new Date(d).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function ProviderNotesPanel({ customerId }) {
+  const [notes, setNotes] = useState([]);
+  const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef(null);
+
+  async function load() {
+    if (!customerId) return;
+    setLoading(true);
+    try {
+      const data = await api(`/api/provider-notes/notes/${customerId}`);
+      setNotes(data || []);
+    } catch (e) {
+      setNotes([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [customerId]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [notes]);
+
+  async function addNote(e) {
+    e.preventDefault();
+    if (!input.trim() || !customerId) return;
+    setSending(true);
+    try {
+      await api("/api/provider-notes/notes", {
+        method: "POST",
+        body: { customer_id: customerId, content: input.trim() },
+      });
+      setInput("");
+      await load();
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function doSearch(e) {
+    e.preventDefault();
+    if (!query.trim()) {
+      setSearching(false);
+      await load();
+      return;
+    }
+    setSearching(true);
+    try {
+      const data = await api(`/api/provider-notes/notes/search?q=${encodeURIComponent(query.trim())}`);
+      setNotes(data || []);
+    } catch (err) {
+      setNotes([]);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-outline-variant bg-surface-container-lowest shadow-card overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-outline-variant bg-surface-container-high px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Lock className="h-3.5 w-3.5 text-on-surface-variant" />
+          <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+            Private Notes
+          </span>
+        </div>
+        <span className="text-[10px] text-on-surface-variant">
+          {notes.length} note{notes.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Search bar */}
+      <form onSubmit={doSearch} className="flex items-center gap-2 border-b border-outline-variant bg-surface-container-low px-3 py-2">
+        <Search className="h-3.5 w-3.5 text-on-surface-variant" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search all customer notes..."
+          className="flex-1 bg-transparent text-xs text-on-surface outline-none placeholder:text-on-surface-variant/60"
+        />
+        {searching && (
+          <button type="button" onClick={() => { setSearching(false); setQuery(""); load(); }} className="text-on-surface-variant hover:text-on-surface">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </form>
+
+      {/* Notes log */}
+      <div ref={scrollRef} className="max-h-[220px] overflow-y-auto px-4 py-3 space-y-3">
+        {loading && <p className="text-xs text-on-surface-variant text-center py-4">Loading...</p>}
+        {!loading && notes.length === 0 && (
+          <p className="text-xs text-on-surface-variant text-center py-6">
+            {searching ? "No notes match your search." : "No notes yet. Write one below."}
+          </p>
+        )}
+        {notes.map((note, i) => {
+          const prev = notes[i - 1];
+          const showDate = !prev || formatDateLabel(prev.created_at) !== formatDateLabel(note.created_at);
+          return (
+            <div key={note.id} className="space-y-1">
+              {showDate && (
+                <p className="text-[10px] font-semibold text-on-surface-variant/60 uppercase tracking-wide">
+                  {formatDateLabel(note.created_at)}
+                </p>
+              )}
+              <div className="flex gap-2">
+                <div className="mt-1 h-1.5 w-1.5 rounded-full bg-primary-container/50 shrink-0" />
+                <div className="min-w-0">
+                  <p className="text-sm text-on-surface whitespace-pre-wrap break-words">{note.content}</p>
+                  <p className="mt-0.5 text-[10px] text-on-surface-variant/50">{formatTime(note.created_at)}</p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Input */}
+      <form onSubmit={addNote} className="flex items-center gap-2 border-t border-outline-variant bg-surface-container-low px-3 py-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Add a private note..."
+          className="flex-1 rounded-md border border-outline-variant bg-surface px-3 py-1.5 text-xs text-on-surface outline-none focus:ring-1 focus:ring-primary-container"
+        />
+        <button
+          type="submit"
+          disabled={sending || !input.trim()}
+          className="rounded-md bg-primary-container p-1.5 text-on-primary disabled:opacity-40 hover:bg-primary transition"
+        >
+          <Send className="h-3.5 w-3.5" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/organiser/BookingsList.jsx
+++ b/frontend/src/pages/organiser/BookingsList.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Button } from "../../components/ui/Button.jsx";
 import { Badge } from "../../components/ui/Badge.jsx";
 import { Modal } from "../../components/ui/Modal.jsx";
+import { ProviderNotesPanel } from "../../components/provider/ProviderNotesPanel.jsx";
+import { CustomerTags } from "../../components/provider/CustomerTags.jsx";
 import { api } from "../../services/api.js";
 
 const toneMap = { confirmed: "success", pending: "warning", cancelled: "danger" };
@@ -59,6 +61,7 @@ export default function BookingsList() {
           <thead className="border-b border-outline-variant bg-surface-container-low">
             <tr>
               <th className="px-4 py-3 text-xs font-bold uppercase text-on-surface-variant">#</th>
+              <th className="px-4 py-3 text-xs font-bold uppercase text-on-surface-variant">Customer</th>
               <th className="px-4 py-3 text-xs font-bold uppercase text-on-surface-variant">Booked on</th>
               <th className="px-4 py-3 text-xs font-bold uppercase text-on-surface-variant">Start</th>
               <th className="px-4 py-3 text-xs font-bold uppercase text-on-surface-variant">End</th>
@@ -75,6 +78,7 @@ export default function BookingsList() {
                 onClick={() => setDetail(b)}
               >
                 <td className="px-4 py-3 font-medium">{b.id}</td>
+                <td className="px-4 py-3 text-on-surface">{b.customer_name || `User #${b.customer_id}`}</td>
                 <td className="px-4 py-3 text-on-surface-variant">{new Date(b.created_at || b.start_time).toLocaleDateString()}</td>
                 <td className="px-4 py-3">{new Date(b.start_time).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</td>
                 <td className="px-4 py-3">{new Date(b.end_time).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</td>
@@ -93,7 +97,7 @@ export default function BookingsList() {
               </tr>
             ))}
             {!rows.length && (
-              <tr><td colSpan={7} className="px-4 py-8 text-center text-on-surface-variant">No bookings found.</td></tr>
+              <tr><td colSpan={8} className="px-4 py-8 text-center text-on-surface-variant">No bookings found.</td></tr>
             )}
           </tbody>
         </table>
@@ -111,6 +115,11 @@ export default function BookingsList() {
             <div className="flex gap-2 pt-2 border-t border-outline-variant">
               {detail.status === "pending" && <Button variant="teal" onClick={() => confirmBooking(detail.id)}>Confirm</Button>}
               {detail.status !== "cancelled" && <Button variant="danger" onClick={() => cancelBooking(detail.id)}>Cancel</Button>}
+            </div>
+            {/* Provider-private CRM panel */}
+            <div className="pt-2 border-t border-outline-variant space-y-3">
+              <CustomerTags customerId={detail.customer_id} />
+              <ProviderNotesPanel customerId={detail.customer_id} />
             </div>
           </div>
         )}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,13 +6,17 @@ function getToken() {
 
 export async function api(path, options = {}) {
   const headers = { ...(options.headers || {}) };
-  if (!(options.body instanceof FormData)) {
+  let body = options.body;
+  if (!(body instanceof FormData)) {
     headers["Content-Type"] = headers["Content-Type"] || "application/json";
+    if (body && typeof body === "object") {
+      body = JSON.stringify(body);
+    }
   }
   const t = getToken();
   if (t) headers["Authorization"] = `Bearer ${t}`;
 
-  const res = await fetch(`${base()}${path}`, { ...options, headers });
+  const res = await fetch(`${base()}${path}`, { ...options, headers, body });
   const text = await res.text();
   let data = null;
   try {


### PR DESCRIPTION
Backend:
- Add ProviderNote and CustomerTag SQLAlchemy models with Alembic migration (012)
- Add Pydantic schemas and /api/provider-notes CRUD router
- Notes: append-only journal per customer, with cross-customer search
- Tags: colored pills, system-suggested + custom, add/remove

Frontend:
- ProviderNotesPanel: journal-style, date-grouped, scrollable, with search across all notes
- CustomerTags: quick-add from suggestions, click-to-remove, private lock icon
- Integrated into BookingsList detail modal
- Added customer_name column to organiser bookings table
- Fixed api.js JSON body stringification bug